### PR TITLE
Corrected typo in get() function

### DIFF
--- a/jquery.onscreen.js
+++ b/jquery.onscreen.js
@@ -395,7 +395,7 @@
             
         },
 
-        get: function get($element) {
+        get: function($element) {
 
             if ($element.length == 0) return;
 


### PR DESCRIPTION
This was causing errors in IE 11.